### PR TITLE
Make calling the user_info endpoint optional

### DIFF
--- a/lib/omniauth/openid_connect/version.rb
+++ b/lib/omniauth/openid_connect/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module OpenIDConnect
-    VERSION = '0.9.1'
+    VERSION = '0.9.5'
   end
 end


### PR DESCRIPTION
This PR makes it so that the user_info endpoint is not called when the Omiauth setting `skip_info` is set.

This is useful for example when integrating with Azure AD B2C, which does not expose this endpoint. It may also be useful in cases where we only care about the ID or access token - this will save one HTTP call.

I also run the file through prettifier to make the syntax consistent, I hope that is ok.

Also note the version bump to `0.9.5`, but feel free to update this as necessary.